### PR TITLE
Fix Shimmer text visibility in dark mode

### DIFF
--- a/Shared (Extension)/Resources/popup.css
+++ b/Shared (Extension)/Resources/popup.css
@@ -410,12 +410,19 @@ body:not(.macos) {
 
 /* Shimmer effect for text */
 .text-shimmer {
+  color: transparent !important;
   background: linear-gradient(90deg, #ccc 0%, #fff 50%, #ccc 100%);
   background-size: 200% 100%;
   background-clip: text;
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  -webkit-text-fill-color: transparent !important;
   animation: text-shimmer 2.5s infinite linear;
+}
+
+@media (prefers-color-scheme: dark) {
+  .text-shimmer {
+    background: linear-gradient(90deg, #444 0%, #666 50%, #444 100%);
+  }
 }
 
 @keyframes text-shimmer {


### PR DESCRIPTION
## Summary
- force `.text-shimmer` text to be transparent and clip gradient
- add dark mode gradient override for visible shimmer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896b50ac6b083229a7ea8f2cbe261fc