### PR TITLE
fix: Show shimmer effect in dark mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+EisonAI is a Safari browser extension that uses Large Language Models (LLMs) to summarize web page content. It's built as a native application for macOS and iOS that contains a Safari Web Extension.
+
+- **Frontend:** The extension's UI is built with HTML, CSS, and JavaScript.
+- **Backend:** The core logic is in JavaScript, split into content scripts, background scripts, and popup/settings scripts.
+- **Native Wrapper:** The Xcode project (`eisonAI.xcodeproj`) wraps the web extension for distribution on the App Store.
+
+## Key Files and Directories
+
+- `Shared (App)/`: Contains the core web extension assets and JavaScript files.
+  - `Base.lproj/Main.html`: The main HTML file for the popup interface.
+  - `Resources/`: Holds JavaScript (`Script.js`) and CSS (`Style.css`).
+  - `ViewController.swift`: The main view controller for the native app wrapper.
+- `macOS (App)/` & `iOS (App)/`: Platform-specific code and configurations.
+- `eisonAI.xcodeproj/`: The Xcode project file.
+
+## Common Development Tasks
+
+### Running the Project
+
+To develop and run the project, you need to use Xcode.
+
+1.  **Install dependencies:**
+    ```bash
+    bundle install
+    ```
+2.  **Open the project in Xcode:**
+    ```bash
+    open eisonAI.xcodeproj
+    ```
+3.  **Run the app:**
+    - Select the desired target (e.g., "eisonAI (macOS)") and a simulator or connected device.
+    - Click the "Run" button in Xcode.
+
+### Modifying the Web Extension
+
+- The primary logic for the Safari extension is located in `Shared (App)/Resources/`.
+- `Script.js` likely contains the main application logic (content extraction, API calls, UI updates).
+- `Style.css` contains the styling for the popup.
+- After making changes to the JavaScript or CSS files, you will need to re-run the application from Xcode to see the changes in Safari.

--- a/Shared (Extension)/Resources/popup.css
+++ b/Shared (Extension)/Resources/popup.css
@@ -410,12 +410,19 @@ body:not(.macos) {
 
 /* Shimmer effect for text */
 .text-shimmer {
+  color: transparent !important;
   background: linear-gradient(90deg, #ccc 0%, #fff 50%, #ccc 100%);
   background-size: 200% 100%;
   background-clip: text;
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+  -webkit-text-fill-color: transparent !important;
   animation: text-shimmer 2.5s infinite linear;
+}
+
+@media (prefers-color-scheme: dark) {
+  .text-shimmer {
+    background: linear-gradient(90deg, #444 0%, #666 50%, #444 100%);
+  }
 }
 
 @keyframes text-shimmer {

--- a/Shared (Extension)/Resources/popup.css
+++ b/Shared (Extension)/Resources/popup.css
@@ -422,6 +422,9 @@ body:not(.macos) {
 @media (prefers-color-scheme: dark) {
   .text-shimmer {
     background: linear-gradient(90deg, #444 0%, #666 50%, #444 100%);
+    background-size: 200% 100%;
+    background-clip: text;
+    -webkit-background-clip: text;
   }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where the shimmer effect on text was not visible in dark mode.

- **CSS Fix**: Modified `Shared (Extension)/Resources/popup.css` to correctly apply all necessary background properties for the shimmer animation within the dark mode media query. This ensures the effect is visible in both light and dark themes.
- **CLAUDE.md**: Added a `CLAUDE.md` file to provide guidance and context for AI assistants working within this repository.

## Test plan

1.  Enable the extension in Safari.
2.  Trigger the shimmer effect within the extension's popup.
3.  Switch your system's appearance between Light and Dark mode.
4.  Confirm the shimmer animation is visible and working as expected in both modes.

🤖 Generated with [Claude Code](https://claude.ai/code)