### PR TITLE
feat(mlx): integrate persistent Drops progress for MLX downloads

### DIFF
--- a/eisonAI.xcodeproj/project.pbxproj
+++ b/eisonAI.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 			packageReferences = (
 				19CEC796B1633FE031717595 /* XCLocalSwiftPackageReference "../AnyLanguageModel" */,
 				A1F642F326514D8F91A90311 /* XCLocalSwiftPackageReference "Packages/EisonAIModelKit" */,
-				EABCD6802F00650B0013F6F9 /* XCLocalSwiftPackageReference "../Drops" */,
+				EABCD6802F00650B0013F6F9 /* XCRemoteSwiftPackageReference "Drops" */,
 				EA9655212F18CBE700936E0D /* XCRemoteSwiftPackageReference "swift-collections" */,
 				A8E53E4312F8745B400FA777 /* XCRemoteSwiftPackageReference "textual" */,
 			);
@@ -1280,10 +1280,6 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/EisonAIModelKit;
 		};
-		EABCD6802F00650B0013F6F9 /* XCLocalSwiftPackageReference "../Drops" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../Drops;
-		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -1301,6 +1297,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.3.0;
+			};
+		};
+		EABCD6802F00650B0013F6F9 /* XCRemoteSwiftPackageReference "Drops" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/qoli/Drops.git";
+			requirement = {
+				branch = "codex/progress-ring-mlx";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1333,7 +1337,7 @@
 		};
 		EABCD6812F00650B0013F6F9 /* Drops */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = EABCD6802F00650B0013F6F9 /* XCLocalSwiftPackageReference "../Drops" */;
+			package = EABCD6802F00650B0013F6F9 /* XCRemoteSwiftPackageReference "Drops" */;
 			productName = Drops;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/eisonAI.xcodeproj/project.pbxproj
+++ b/eisonAI.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 			packageReferences = (
 				19CEC796B1633FE031717595 /* XCLocalSwiftPackageReference "../AnyLanguageModel" */,
 				A1F642F326514D8F91A90311 /* XCLocalSwiftPackageReference "Packages/EisonAIModelKit" */,
-				EABCD6802F00650B0013F6F9 /* XCRemoteSwiftPackageReference "Drops" */,
+				EABCD6802F00650B0013F6F9 /* XCLocalSwiftPackageReference "../Drops" */,
 				EA9655212F18CBE700936E0D /* XCRemoteSwiftPackageReference "swift-collections" */,
 				A8E53E4312F8745B400FA777 /* XCRemoteSwiftPackageReference "textual" */,
 			);
@@ -1280,6 +1280,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/EisonAIModelKit;
 		};
+		EABCD6802F00650B0013F6F9 /* XCLocalSwiftPackageReference "../Drops" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../Drops;
+		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -1297,14 +1301,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.3.0;
-			};
-		};
-		EABCD6802F00650B0013F6F9 /* XCRemoteSwiftPackageReference "Drops" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/omaralbeik/Drops.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1337,7 +1333,7 @@
 		};
 		EABCD6812F00650B0013F6F9 /* Drops */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = EABCD6802F00650B0013F6F9 /* XCRemoteSwiftPackageReference "Drops" */;
+			package = EABCD6802F00650B0013F6F9 /* XCLocalSwiftPackageReference "../Drops" */;
 			productName = Drops;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/iOS (App)/Features/Settings/AIModelsSettingsMLXComponents.swift
+++ b/iOS (App)/Features/Settings/AIModelsSettingsMLXComponents.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+
+struct MLXInstalledModelRow: View {
+    let model: InstalledMLXModel
+    let metadataLine: String
+    let isSelected: Bool
+    let isBusy: Bool
+    let onSelect: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(model.id)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            Text(metadataLine)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                if isSelected {
+                    Label("Selected", systemImage: "checkmark.circle.fill")
+                        .font(.footnote)
+                        .foregroundStyle(.green)
+                } else {
+                    Button("Select", action: onSelect)
+                }
+
+                Spacer()
+
+                if isBusy {
+                    ProgressView()
+                } else {
+                    Button("Delete", role: .destructive, action: onDelete)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct MLXCatalogModelRow: View {
+    let model: MLXCatalogModel
+    let metadataLine: String
+    let recommendation: MLXCatalogModel.Recommendation
+    let isInstalled: Bool
+    let isSelected: Bool
+    let job: MLXDownloadJob?
+    let isInstallDisabled: Bool
+    let onSelect: () -> Void
+    let onInstall: () -> Void
+    let onCancelDownload: () -> Void
+    let onDismissJob: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(model.displayName)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            Text(metadataLine)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                MLXRecommendationBadge(recommendation: recommendation)
+
+                Spacer()
+
+                trailingControl
+            }
+
+            if let job {
+                MLXDownloadJobStatusView(
+                    job: job,
+                    onCancel: onCancelDownload,
+                    onDismiss: onDismissJob
+                )
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var trailingControl: some View {
+        if let job {
+            if job.isActive {
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(job.progressText)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+
+                    MLXDownloadProgressView(job: job, compact: true)
+                }
+            } else {
+                Text(job.progressText)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+        } else if isInstalled {
+            Button(isSelected ? "Selected" : "Select", action: onSelect)
+                .disabled(isSelected)
+        } else {
+            Button("Install", action: onInstall)
+                .disabled(isInstallDisabled)
+        }
+    }
+}
+
+struct MLXActiveDownloadBanner: View {
+    let job: MLXDownloadJob
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Another MLX download is in progress: \(job.displayName)")
+                    .foregroundStyle(.secondary)
+
+                MLXDownloadProgressView(job: job)
+            }
+
+            Spacer()
+
+            Button("Cancel", role: .destructive, action: onCancel)
+                .font(.footnote)
+        }
+    }
+}
+
+struct MLXDownloadJobStatusView: View {
+    let job: MLXDownloadJob
+    let onCancel: () -> Void
+    let onDismiss: () -> Void
+
+    private var isError: Bool {
+        job.state == .failed || job.state == .cancelled
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(job.progressText)
+                .font(.footnote)
+                .foregroundStyle(isError ? .red : .secondary)
+
+            if job.isActive {
+                MLXDownloadProgressView(job: job)
+            }
+
+            if let errorMessage = job.errorMessage,
+               !errorMessage.isEmpty,
+               isError
+            {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            if job.isActive {
+                Button("Cancel Download", role: .destructive, action: onCancel)
+                    .font(.footnote)
+            } else if isError {
+                Button("Dismiss", action: onDismiss)
+                    .font(.footnote)
+            }
+        }
+    }
+}
+
+struct MLXDownloadProgressView: View {
+    let job: MLXDownloadJob
+    var compact = false
+
+    var body: some View {
+        if let progressValue = normalizedProgress {
+            ProgressView(value: progressValue)
+                .frame(width: compact ? 88 : nil)
+        } else {
+            ProgressView()
+                .controlSize(compact ? .mini : .small)
+        }
+    }
+
+    private var normalizedProgress: Double? {
+        if job.totalUnitCount > 0 {
+            return min(1, max(0, Double(job.completedUnitCount) / Double(max(job.totalUnitCount, 1))))
+        }
+        guard job.fractionCompleted > 0 else { return nil }
+        return min(1, max(0, job.fractionCompleted))
+    }
+}
+
+struct MLXRecommendationBadge: View {
+    let recommendation: MLXCatalogModel.Recommendation
+
+    var body: some View {
+        Text(recommendation.label)
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(badgeColor.opacity(0.12))
+            .foregroundStyle(badgeColor)
+            .clipShape(Capsule())
+    }
+
+    private var badgeColor: Color {
+        switch recommendation {
+        case .recommended:
+            return .green
+        case .caution:
+            return .orange
+        case .likelyTooLarge:
+            return .red
+        case .unknown:
+            return .secondary
+        }
+    }
+}

--- a/iOS (App)/Features/Settings/AIModelsSettingsPreviews.swift
+++ b/iOS (App)/Features/Settings/AIModelsSettingsPreviews.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+
+#Preview("AI Models") {
+    NavigationStack {
+        AIModelsSettingsView()
+    }
+}
+
+#Preview("MLX Download Style") {
+    MLXModelsDownloadStylePreview()
+}
+
+private struct MLXModelsDownloadStylePreview: View {
+    private let activeJob = MLXDownloadJob(
+        taskIdentifier: "preview-task",
+        modelID: "mlx-community/translategemma-4b-it-4bit_immersive-translate",
+        displayName: "translategemma-4b-it-4bit_immersive-translate",
+        source: .catalog,
+        state: .running,
+        completedUnitCount: 182,
+        totalUnitCount: 1024,
+        fractionCompleted: 0.18,
+        autoSelectOnCompletion: true,
+        catalogModel: MLXCatalogModel(
+            id: "mlx-community/translategemma-4b-it-4bit_immersive-translate",
+            pipelineTag: "text-generation",
+            baseModel: "google/translategemma-4b-it",
+            lastModified: .now.addingTimeInterval(-86_400),
+            estimatedParameterCount: 4_000_000_000,
+            rawSafeTensorTotal: 606_600_000
+        )
+    )
+
+    private let otherModels: [MLXCatalogModel] = [
+        MLXCatalogModel(
+            id: "mlx-community/gemma-4-31B-it-The-DECKARD-HERETIC-UNCENSORED-Thinking-4.6bit-msq",
+            pipelineTag: "image-text-to-text",
+            baseModel: "google/gemma-4-31B-it",
+            lastModified: .now.addingTimeInterval(-86_400),
+            estimatedParameterCount: 31_000_000_000,
+            rawSafeTensorTotal: 31_250_000_000
+        ),
+        MLXCatalogModel(
+            id: "mlx-community/Qwen3.5-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-4.5bit-msq",
+            pipelineTag: "image-text-to-text",
+            baseModel: "DavidAU/Qwen3.5-27B-Deckard-PKD-Heretic-Uncensored-Thinking",
+            lastModified: .now.addingTimeInterval(-86_400),
+            estimatedParameterCount: 40_000_000_000,
+            rawSafeTensorTotal: 39_530_000_000
+        )
+    ]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("mlx-community") {
+                    MLXActiveDownloadBanner(job: activeJob, onCancel: {})
+                    previewCatalogRow(
+                        model: activeJob.catalogModel ?? otherModels[0],
+                        trailingTitle: "Downloading 18%",
+                        progress: 0.18,
+                        actionTitle: "Cancel Download",
+                        actionRole: .destructive
+                    )
+                    previewCatalogRow(
+                        model: otherModels[0],
+                        trailingTitle: "Install",
+                        progress: nil,
+                        actionTitle: nil,
+                        actionRole: nil
+                    )
+                    previewCatalogRow(
+                        model: otherModels[1],
+                        trailingTitle: "Install",
+                        progress: nil,
+                        actionTitle: nil,
+                        actionRole: nil
+                    )
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("MLX Models")
+            .safeAreaInset(edge: .top, spacing: 12) {
+                MLXDownloadToastPreview(job: activeJob)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+            }
+            .background(Color(uiColor: .systemGroupedBackground))
+        }
+    }
+
+    @ViewBuilder
+    private func previewCatalogRow(
+        model: MLXCatalogModel,
+        trailingTitle: String,
+        progress: Double?,
+        actionTitle: String?,
+        actionRole: ButtonRole?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(model.displayName)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            Text(previewCatalogMetadataLine(model))
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                MLXRecommendationBadge(recommendation: MLXCatalogModel.Recommendation.recommended)
+
+                Spacer()
+
+                if let progress {
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Text(trailingTitle)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                        ProgressView(value: progress)
+                            .frame(width: 96)
+                    }
+                } else {
+                    Text(trailingTitle)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if let progress {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Downloading 18%")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    ProgressView(value: progress)
+                    if let actionTitle {
+                        Button(actionTitle, role: actionRole) {}
+                            .font(.footnote)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func previewCatalogMetadataLine(_ model: MLXCatalogModel) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useGB, .useMB]
+        formatter.countStyle = .file
+        formatter.isAdaptive = true
+
+        let size = model.rawSafeTensorTotal.map { formatter.string(fromByteCount: $0) } ?? "Unknown size"
+        let params = model.estimatedParameterLabel
+        let base = model.baseModel ?? "Unknown base"
+        return [model.pipelineTag, size, params, base].joined(separator: " · ")
+    }
+}
+
+private struct MLXDownloadToastPreview: View {
+    let job: MLXDownloadJob
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: "arrow.down.circle")
+                .font(.system(size: 28, weight: .regular))
+                .foregroundStyle(.secondary)
+                .frame(width: 34, height: 34)
+
+            VStack(alignment: .center, spacing: 2) {
+                Text("Downloading MLX Model")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Text("\(job.displayName) · 18%")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity)
+
+            ZStack {
+                Circle()
+                    .stroke(Color(uiColor: .tertiaryLabel).opacity(0.35), lineWidth: 3)
+                Circle()
+                    .trim(from: 0, to: 0.18)
+                    .stroke(
+                        Color.accentColor,
+                        style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+            }
+            .frame(width: 30, height: 30)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(.ultraThinMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .stroke(Color.white.opacity(0.45), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.08), radius: 20, y: 10)
+    }
+}

--- a/iOS (App)/Features/Settings/AIModelsSettingsView.swift
+++ b/iOS (App)/Features/Settings/AIModelsSettingsView.swift
@@ -471,11 +471,14 @@ struct AIModelsSettingsView: View {
         return parts.joined(separator: " · ")
     }
 
+    private var deviceRAMGiB: Double {
+        Double(ProcessInfo.processInfo.physicalMemory) / 1024 / 1024 / 1024
+    }
+
     private var filteredCatalogModels: [MLXCatalogModel] {
         guard !showAllCatalogModels else { return catalogModels }
-        let ramGiB = Double(ProcessInfo.processInfo.physicalMemory) / 1024 / 1024 / 1024
         return catalogModels.filter { model in
-            model.recommendation(forRAMGiB: ramGiB) != .likelyTooLarge
+            model.recommendation(forRAMGiB: deviceRAMGiB) != .likelyTooLarge
         }
     }
 
@@ -529,7 +532,11 @@ struct AIModelsSettingsView: View {
                     if let customDownloadJob,
                        customDownloadJob.source == .custom
                     {
-                        downloadJobStatusView(customDownloadJob)
+                        MLXDownloadJobStatusView(
+                            job: customDownloadJob,
+                            onCancel: cancelCurrentDownloadJob,
+                            onDismiss: dismissCurrentDownloadJob
+                        )
                     }
                 } header: {
                     Text("Custom MLX Repo")
@@ -542,7 +549,23 @@ struct AIModelsSettingsView: View {
             if !installedModels.isEmpty {
                 Section {
                     ForEach(installedModels, id: \.id) { model in
-                        installedModelRow(model)
+                        MLXInstalledModelRow(
+                            model: model,
+                            metadataLine: installedMetadataLine(model),
+                            isSelected: selectedMLXModelID == model.id,
+                            isBusy: activeModelOperationIDs.contains(model.id),
+                            onSelect: { selectInstalledModel(id: model.id) },
+                            onDelete: { deleteInstalledModel(id: model.id) }
+                        )
+                        .onAppear {
+                            logInstalledRowState(model, context: "appear")
+                        }
+                        .onChange(of: activeModelOperationIDs) { _, _ in
+                            logInstalledRowState(model, context: "activeModelOperationIDs changed")
+                        }
+                        .onChange(of: selectedMLXModelID) { _, _ in
+                            logInstalledRowState(model, context: "selectedMLXModelID changed")
+                        }
                     }
                 } header: {
                     Text("Installed")
@@ -553,21 +576,10 @@ struct AIModelsSettingsView: View {
                 if let activeDownloadJob,
                    activeDownloadJob.modelID != customRepoDraft.trimmingCharacters(in: .whitespacesAndNewlines)
                 {
-                    HStack(alignment: .top, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Another MLX download is in progress: \(activeDownloadJob.displayName)")
-                                .foregroundStyle(.secondary)
-
-                            activeDownloadProgressView(activeDownloadJob)
-                        }
-
-                        Spacer()
-
-                        Button("Cancel", role: .destructive) {
-                            cancelCurrentDownloadJob()
-                        }
-                        .font(.footnote)
-                    }
+                    MLXActiveDownloadBanner(
+                        job: activeDownloadJob,
+                        onCancel: cancelCurrentDownloadJob
+                    )
                 } else if let blockingTerminalJob = currentDownloadJob,
                           !blockingTerminalJob.isActive
                 {
@@ -595,7 +607,19 @@ struct AIModelsSettingsView: View {
                 }
 
                 ForEach(filteredCatalogModels, id: \.id) { model in
-                    catalogRow(model)
+                    MLXCatalogModelRow(
+                        model: model,
+                        metadataLine: catalogMetadataLine(model),
+                        recommendation: model.recommendation(forRAMGiB: deviceRAMGiB),
+                        isInstalled: installedModels.contains(where: { $0.id == model.id }),
+                        isSelected: selectedMLXModelID == model.id,
+                        job: downloadJob(for: model.id),
+                        isInstallDisabled: activeDownloadJob != nil,
+                        onSelect: { selectInstalledModel(id: model.id) },
+                        onInstall: { installCatalogModel(model) },
+                        onCancelDownload: cancelCurrentDownloadJob,
+                        onDismissJob: dismissCurrentDownloadJob
+                    )
                 }
             } header: {
                 Text("mlx-community")
@@ -666,127 +690,6 @@ struct AIModelsSettingsView: View {
             case .queued, .running, .finishing:
                 break
             }
-        }
-    }
-
-    @ViewBuilder
-    private func installedModelRow(_ model: InstalledMLXModel) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(model.id)
-                .font(.subheadline)
-                .fontWeight(.semibold)
-
-            Text(installedMetadataLine(model))
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-
-            HStack {
-                if selectedMLXModelID == model.id {
-                    Label("Selected", systemImage: "checkmark.circle.fill")
-                        .font(.footnote)
-                        .foregroundStyle(.green)
-                } else {
-                    Button("Select") {
-                        selectInstalledModel(id: model.id)
-                    }
-                }
-
-                Spacer()
-
-                if activeModelOperationIDs.contains(model.id) {
-                    ProgressView()
-                } else {
-                    Button("Delete", role: .destructive) {
-                        deleteInstalledModel(id: model.id)
-                    }
-                }
-            }
-        }
-        .padding(.vertical, 4)
-        .onAppear {
-            logInstalledRowState(model, context: "appear")
-        }
-        .onChange(of: activeModelOperationIDs) { _, _ in
-            logInstalledRowState(model, context: "activeModelOperationIDs changed")
-        }
-        .onChange(of: selectedMLXModelID) { _, _ in
-            logInstalledRowState(model, context: "selectedMLXModelID changed")
-        }
-    }
-
-    @ViewBuilder
-    private func catalogRow(_ model: MLXCatalogModel) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(model.displayName)
-                .font(.subheadline)
-                .fontWeight(.semibold)
-
-            Text(catalogMetadataLine(model))
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-
-            HStack {
-                recommendationBadge(for: model)
-
-                Spacer()
-
-                if let job = downloadJob(for: model.id) {
-                    if job.isActive {
-                        VStack(alignment: .trailing, spacing: 4) {
-                            Text(job.progressText)
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-
-                            activeDownloadProgressView(job, compact: true)
-                        }
-                    } else {
-                        Text(job.progressText)
-                            .font(.footnote)
-                            .foregroundStyle(.red)
-                    }
-                } else if installedModels.contains(where: { $0.id == model.id }) {
-                    Button(selectedMLXModelID == model.id ? "Selected" : "Select") {
-                        selectInstalledModel(id: model.id)
-                    }
-                    .disabled(selectedMLXModelID == model.id)
-                } else {
-                    Button("Install") {
-                        installCatalogModel(model)
-                    }
-                    .disabled(activeDownloadJob != nil)
-                }
-            }
-
-            if let job = downloadJob(for: model.id) {
-                downloadJobStatusView(job)
-            }
-        }
-        .padding(.vertical, 4)
-    }
-
-    @ViewBuilder
-    private func recommendationBadge(for model: MLXCatalogModel) -> some View {
-        let ramGiB = Double(ProcessInfo.processInfo.physicalMemory) / 1024 / 1024 / 1024
-        let recommendation = model.recommendation(forRAMGiB: ramGiB)
-        Text(recommendation.label)
-            .font(.caption)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(recommendationColor(recommendation).opacity(0.12))
-            .foregroundStyle(recommendationColor(recommendation))
-            .clipShape(Capsule())
-    }
-
-    private func recommendationColor(_ recommendation: MLXCatalogModel.Recommendation) -> Color {
-        switch recommendation {
-        case .recommended:
-            return .green
-        case .caution:
-            return .orange
-        case .likelyTooLarge:
-            return .red
-        case .unknown:
-            return .secondary
         }
     }
 
@@ -1090,60 +993,6 @@ struct AIModelsSettingsView: View {
         Self.logger.xcodeNotice(
             "mlxUI context=\(context) installed=\(installedModels.map { $0.id }.sorted()) selected=\(selectedMLXModelID ?? "nil") activeModelOperationIDs=\(activeModelOperationIDs.sorted()) currentDownloadJob=\(jobSummary)"
         )
-    }
-
-    @ViewBuilder
-    private func downloadJobStatusView(_ job: MLXDownloadJob) -> some View {
-        let isError = job.state == .failed || job.state == .cancelled
-        VStack(alignment: .leading, spacing: 4) {
-            Text(job.progressText)
-                .font(.footnote)
-                .foregroundStyle(isError ? .red : .secondary)
-
-            if job.isActive {
-                activeDownloadProgressView(job)
-            }
-
-            if let errorMessage = job.errorMessage,
-               !errorMessage.isEmpty,
-               isError
-            {
-                Text(errorMessage)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-
-            if job.isActive {
-                Button("Cancel Download", role: .destructive) {
-                    cancelCurrentDownloadJob()
-                }
-                .font(.footnote)
-            } else if isError {
-                Button("Dismiss") {
-                    dismissCurrentDownloadJob()
-                }
-                .font(.footnote)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func activeDownloadProgressView(_ job: MLXDownloadJob, compact: Bool = false) -> some View {
-        if let progressValue = normalizedProgress(for: job) {
-            ProgressView(value: progressValue)
-                .frame(width: compact ? 88 : nil)
-        } else {
-            ProgressView()
-                .controlSize(compact ? .mini : .small)
-        }
-    }
-
-    private func normalizedProgress(for job: MLXDownloadJob) -> Double? {
-        if job.totalUnitCount > 0 {
-            return min(1, max(0, Double(job.completedUnitCount) / Double(max(job.totalUnitCount, 1))))
-        }
-        guard job.fractionCompleted > 0 else { return nil }
-        return min(1, max(0, job.fractionCompleted))
     }
 
     private func validateBYOK() {
@@ -1478,11 +1327,5 @@ private enum BYOKPingStatus {
         case .success: return "Success"
         case .failed: return "Failed"
         }
-    }
-}
-
-#Preview {
-    NavigationStack {
-        AIModelsSettingsView()
     }
 }

--- a/iOS (App)/Shared/MLX/MLXDownloadDropNotifier.swift
+++ b/iOS (App)/Shared/MLX/MLXDownloadDropNotifier.swift
@@ -7,12 +7,17 @@ import UIKit
 final class MLXDownloadDropNotifier {
     static let shared = MLXDownloadDropNotifier()
 
+    private enum ProgressSnapshot: Equatable {
+        case indeterminate
+        case percent(Int)
+    }
+
     private let coordinator: MLXDownloadCoordinator
     private let drops: Drops
     private var cancellable: AnyCancellable?
     private var hasStarted = false
     private var lastStateByJobID: [String: MLXDownloadJob.State] = [:]
-    private var lastProgressBucketByJobID: [String: Int] = [:]
+    private var lastProgressSnapshotByJobID: [String: ProgressSnapshot] = [:]
 
     init(
         coordinator: MLXDownloadCoordinator = .shared,
@@ -38,7 +43,7 @@ final class MLXDownloadDropNotifier {
         guard let job else { return }
 
         let previousState = lastStateByJobID[job.jobID]
-        let previousBucket = lastProgressBucketByJobID[job.jobID] ?? -1
+        let previousProgressSnapshot = lastProgressSnapshotByJobID[job.jobID]
 
         switch job.state {
         case .queued:
@@ -51,32 +56,35 @@ final class MLXDownloadDropNotifier {
             )
 
         case .running:
-            let progressBucket = progressBucket(for: job)
             if previousState != .running {
-                show(
-                    title: "Starting MLX Download",
+                showProgress(
+                    title: "Downloading MLX Model",
                     subtitle: progressSubtitle(for: job, fallback: job.displayName),
                     iconName: "arrow.down.circle",
-                    duration: 1.6
+                    progress: progress(for: job),
+                    id: progressDropID(for: job)
                 )
-            } else if let progressBucket, progressBucket > previousBucket {
-                show(
+            } else {
+                let progressSnapshot = progressSnapshot(for: job)
+                guard progressSnapshot != previousProgressSnapshot else { break }
+                showProgress(
                     title: "Downloading MLX Model",
-                    subtitle: "\(job.displayName) · \(progressBucket)%",
+                    subtitle: progressSubtitle(for: job, fallback: job.displayName),
                     iconName: "arrow.down.circle",
-                    duration: 1.4
+                    progress: progress(for: job),
+                    id: progressDropID(for: job)
                 )
             }
-            lastProgressBucketByJobID[job.jobID] = progressBucket ?? previousBucket
+            lastProgressSnapshotByJobID[job.jobID] = progressSnapshot(for: job)
 
         case .finishing:
             guard previousState != .finishing else { break }
-            show(
+            showProgress(
                 title: "Finalizing MLX Model",
                 subtitle: job.displayName,
                 iconName: "hourglass",
-                duration: 1.6,
-                replacingCurrent: true
+                progress: .indeterminate,
+                id: progressDropID(for: job)
             )
 
         case .completed:
@@ -112,27 +120,63 @@ final class MLXDownloadDropNotifier {
 
         lastStateByJobID[job.jobID] = job.state
         if !job.isActive {
-            lastProgressBucketByJobID[job.jobID] = progressBucket(for: job) ?? previousBucket
+            lastProgressSnapshotByJobID.removeValue(forKey: job.jobID)
+            lastStateByJobID.removeValue(forKey: job.jobID)
         }
     }
 
-    private func progressBucket(for job: MLXDownloadJob) -> Int? {
-        let fraction = normalizedProgress(for: job)
-        guard fraction > 0 else { return nil }
-        let percent = min(100, Int((fraction * 100).rounded(.down)))
-        return min(100, (percent / 25) * 25)
+    private func progressPercent(for job: MLXDownloadJob) -> Int? {
+        guard let fraction = normalizedProgress(for: job), fraction > 0 else { return nil }
+        return min(100, Int((fraction * 100).rounded(.down)))
     }
 
-    private func normalizedProgress(for job: MLXDownloadJob) -> Double {
+    private func normalizedProgress(for job: MLXDownloadJob) -> Double? {
         if job.totalUnitCount > 0 {
             return min(1, max(0, Double(job.completedUnitCount) / Double(max(job.totalUnitCount, 1))))
         }
+        guard job.fractionCompleted > 0 else { return nil }
         return min(1, max(0, job.fractionCompleted))
     }
 
     private func progressSubtitle(for job: MLXDownloadJob, fallback: String) -> String {
-        guard let progressBucket = progressBucket(for: job) else { return fallback }
-        return "\(job.displayName) · \(progressBucket)%"
+        guard let progressPercent = progressPercent(for: job) else { return fallback }
+        return "\(job.displayName) · \(progressPercent)%"
+    }
+
+    private func progress(for job: MLXDownloadJob) -> Drop.Progress {
+        if let normalizedProgress = normalizedProgress(for: job) {
+            return .determinate(normalizedProgress)
+        }
+        return .indeterminate
+    }
+
+    private func progressSnapshot(for job: MLXDownloadJob) -> ProgressSnapshot {
+        if let progressPercent = progressPercent(for: job) {
+            return .percent(progressPercent)
+        }
+        return .indeterminate
+    }
+
+    private func progressDropID(for job: MLXDownloadJob) -> String {
+        "mlx-download-\(job.jobID)"
+    }
+
+    private func showProgress(
+        title: String,
+        subtitle: String,
+        iconName: String,
+        progress: Drop.Progress,
+        id: String
+    ) {
+        let drop = Drop(
+            title: title,
+            subtitle: subtitle,
+            icon: UIImage(systemName: iconName),
+            duration: .untilHidden,
+            id: id,
+            progress: progress
+        )
+        drops.show(drop)
     }
 
     private func show(


### PR DESCRIPTION
## Summary
- integrate the Drops progress-ring branch into `eisonAI` for MLX download notifications
- keep MLX download progress in a single persistent drop instead of emitting repeated toasts
- split `AIModelsSettingsView` into smaller MLX view components and dedicated SwiftUI previews

## Changes
- point `Drops` to `https://github.com/qoli/Drops.git` on `codex/progress-ring-mlx`
- add persistent MLX download drop updates backed by the current MLX download coordinator flow
- add an `MLX Download Style` SwiftUI preview for the MLX Models screen
- extract MLX row, banner, progress, and preview views out of `AIModelsSettingsView`

## Verification
- `xcodebuild build -project eisonAI.xcodeproj -scheme iOS -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''`

## Notes
- this PR currently depends on `qoli/Drops` branch `codex/progress-ring-mlx`
